### PR TITLE
Improve host listening check

### DIFF
--- a/pschecker/checks/host_listening.py
+++ b/pschecker/checks/host_listening.py
@@ -10,20 +10,30 @@ description = """Servers should not listen 0.0.0.0 except reverse proxy and
 SSH server."""
 
 UNKNOWN_PORT_LIMIT = 1024
-EVERY_IP = "0.0.0.0"
+EVERY_IPS = ["0.0.0.0", ":::"]
+XMPP_PORTS = [5222, 5223, 5269, 5298]
 
 
 def run_check(config):
-    lines = get_lines_from_command("netstat -ltn | grep 0.0.0.0")
+    lines = get_lines_from_command("sudo netstat -pltn | grep 0.0.0.0")
+    lines = lines + get_lines_from_command("sudo netstat -pltn | grep 0\ :::")
 
     unexpected_open_ports = []
 
     for line in lines:
         column = str(line).split()
         host = column[3]
-        port = int(host.split(":")[1])
-        if port > UNKNOWN_PORT_LIMIT and EVERY_IP in host:
-            unexpected_open_ports.append(str(port))
+        if host[:3] == ":::":
+            port = int(host[3:])
+            host = ":::"
+        else:
+            port = int(host.split(":")[1])
+            host = "0.0.0.0"
+        name = column[6].split("/")[1]
+        if port > UNKNOWN_PORT_LIMIT \
+           and port not in XMPP_PORTS \
+           and host in EVERY_IPS:
+            unexpected_open_ports.append("%s (%s)" % (name, str(port)))
 
     if len(unexpected_open_ports) == 0:
         return {
@@ -32,6 +42,6 @@ def run_check(config):
     else:
         return {
             "status": "FAILURE",
-            "message": "Some of your servers listen to the 0.0.0.0 host."
-                       "(ports: %s)" % ", ".join(unexpected_open_ports)
+            "message": "Some of your servers listen to the 0.0.0.0 host:"
+                       " %s " % ", ".join(unexpected_open_ports)
         }


### PR DESCRIPTION
**Problem**

* There is nothing wrong with having XMPP server listening on 0.0.0.0.
* `netstat` command returns `:::` when listing some process listening for every ips.
* When there is a process listening for every ips, in the error message its port is given but not its name.

**Solution**

* Exclude XMPP ports
* Include host with `:::` as IP.
* Display name and port when listing process that listen to every hosts.

