### PR TITLE
Fix python3 case where bytes are returned

### DIFF
--- a/pschecker/helpers.py
+++ b/pschecker/helpers.py
@@ -8,7 +8,9 @@ def get_lines_from_command(command):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT
     )
-    return result.stdout.readlines()
+    lines = result.stdout.readlines()
+    lines = [line.decode() if isinstance(line, bytes) else line for line in lines]
+    return lines
 
 
 def get_first_line_from_command(command):


### PR DESCRIPTION
**Problem**
<!--- Explain the problem -->
Python3 returns `bytes` objects:
```
Traceback (most recent call last):
  File "/root/.virtualenvs/venv_pschecker/bin/pschecker", line 11, in <module>
    sys.exit(cli())
  File "/root/.virtualenvs/venv_pschecker/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/root/.virtualenvs/venv_pschecker/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/root/.virtualenvs/venv_pschecker/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/root/.virtualenvs/venv_pschecker/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/root/.virtualenvs/venv_pschecker/lib/python3.5/site-packages/pschecker/cli.py", line 24, in cli
    run_diagnostic(config)
  File "/root/.virtualenvs/venv_pschecker/lib/python3.5/site-packages/pschecker/cli.py", line 47, in run_diagnostic
    check_runner.run_check(config)
  File "/root/.virtualenvs/venv_pschecker/lib/python3.5/site-packages/pschecker/checks/firewall.py", line 17, in run_check
    is_firewall_up = check_ufw()
  File "/root/.virtualenvs/venv_pschecker/lib/python3.5/site-packages/pschecker/checks/firewall.py", line 33, in check_ufw
    "Status" in lines[0] and \
TypeError: a bytes-like object is required, not 'str'
```

**Solution**
<!--- Describe the change, including rationale and design decisions -->
Check subprocess output and convert if needed.